### PR TITLE
PLAT-939: FIX. Install weighted-levenshtein without Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     },
     setup_requires=[
         # Setuptools 18.0 properly handles Cython extensions.
-        'setuptools>=18.0',
+        'setuptools >= 18.0',
         'cython',
     ],
     ext_modules=extensions,

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ setup(
     ],
     keywords='Levenshtein Damerau weight weighted distance',
     test_suite='test.test',
-    packages=find_packages(exclude=('test', 'docs')),
+    packages=find_packages(exclude=('test', 'docs',)),
     package_data={
-        'weighted_levenshtein': ['clev.pxd', 'clev.pyx']
+        'weighted_levenshtein': ['clev.pxd', 'clev.pyx'],
     },
     setup_requires=[
         # Setuptools 18.0 properly handles Cython extensions.

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,6 @@ from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
 
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    extensions = [Extension("weighted_levenshtein.clev", ['weighted_levenshtein/clev.c'])]
-else:
-    extensions = cythonize([Extension("weighted_levenshtein.clev", ['weighted_levenshtein/clev.pyx'])])
-
-
 with open('README.rst') as readme:
     long_description = readme.read()
 
@@ -50,5 +42,5 @@ setup(
         'setuptools >= 18.0',
         'cython',
     ],
-    ext_modules=extensions,
+    ext_modules=[Extension("weighted_levenshtein.clev", ['weighted_levenshtein/clev.pyx'])],
 )


### PR DESCRIPTION
Currently installing `weighted-levenshtein` without Cython installed results in failure. Instead, Cython should be installed automatically when `weighted-levenshtein` is installed, if it is not already.

Fixes https://github.com/infoscout/weighted-levenshtein/issues/11.