### PR TITLE
Add Unicode and Windows support

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -206,6 +206,9 @@ class TestClevWithUnicode(unittest.TestCase):
     def _osa(self, x, y):
         return osa(x, y, self.iw, self.dw, self.sw, self.tw)
 
+    def _dl(self, x, y):
+        return dam_lev(x, y, self.iw, self.dw, self.sw, self.tw)
+
     def test_lev(self):
         try:
             self.assertEqual(self._lev('átívelődök', 'átívelődök'), 0.0)
@@ -225,5 +228,16 @@ class TestClevWithUnicode(unittest.TestCase):
             self.assertEqual(self._osa('', ''), 0.0)
             self.assertEqual(self._osa('átívelődök', 'átívelőd'), 2.0)
             self.assertEqual(self._osa('', 'ҰǴʚΏ¤☣✐'), 16.0)
+        except UnicodeEncodeError:
+            self.fail("Could not handle special characters")
+
+    def test_dl(self):
+        try:
+            self.assertEqual(self._dl('átívelődök', 'átívelődök'), 0.0)
+            self.assertEqual(self._dl('', 'átívelődök'), 19.0)
+            self.assertEqual(self._dl('átívelődök', ''), 19.0)
+            self.assertEqual(self._dl('', ''), 0.0)
+            self.assertEqual(self._dl('átívelődök', 'átívelőd'), 2.0)
+            self.assertEqual(self._dl('', 'ҰǴʚΏ¤☣✐'), 16.0)
         except UnicodeEncodeError:
             self.fail("Could not handle special characters")

--- a/test/test.py
+++ b/test/test.py
@@ -183,3 +183,47 @@ class TestClevUsingDefaultValues(unittest.TestCase):
         self.assertEqual(dam_lev('bca', 'ab'), 2)
         self.assertEqual(dam_lev('ab', 'bdca'), 3)
         self.assertEqual(dam_lev('bdca', 'ab'), 3)
+
+
+class TestClevWithUnicode(unittest.TestCase):
+
+    def setUp(self):
+        self.iw = np.ones(10001, dtype=np.float64)
+        self.dw = np.ones(10001, dtype=np.float64)
+        self.sw = np.ones((10001, 10001), dtype=np.float64)
+        self.tw = np.ones((10001, 10001), dtype=np.float64)
+        self.iw[ord("á")] = 2.0
+        self.dw[ord("á")] = 2.0
+        self.iw[ord("ő")] = 9.0
+        self.dw[ord("ő")] = 9.0
+        self.iw[ord("Ұ")] = 10.0
+        self.dw[ord("Ұ")] = 10.0
+
+
+    def _lev(self, x, y):
+        return lev(x, y, self.iw, self.dw, self.sw)
+
+    def _osa(self, x, y):
+        return osa(x, y, self.iw, self.dw, self.sw, self.tw)
+
+    def test_lev(self):
+        try:
+            self.assertEqual(self._lev('átívelődök', 'átívelődök'), 0.0)
+            self.assertEqual(self._lev('', 'átívelődök'), 19.0)
+            self.assertEqual(self._lev('átívelődök', ''), 19.0)
+            self.assertEqual(self._lev('', ''), 0.0)
+            self.assertEqual(self._lev('átívelődök', 'átívelőd'), 2.0)
+            self.assertEqual(self._lev('', 'ҰǴʚΏ¤☣✐'), 16.0)
+        except UnicodeEncodeError:
+            self.fail("Could not handle special characters")
+
+    def test_osa(self):
+        try:
+            self.assertEqual(self._osa('átívelődök', 'átívelődök'), 0.0)
+            self.assertEqual(self._osa('', 'átívelődök'), 19.0)
+            self.assertEqual(self._osa('átívelődök', ''), 19.0)
+            self.assertEqual(self._osa('', ''), 0.0)
+            self.assertEqual(self._osa('átívelődök', 'átívelőd'), 2.0)
+            self.assertEqual(self._osa('', 'ҰǴʚΏ¤☣✐'), 16.0)
+        except UnicodeEncodeError:
+            self.fail("Could not handle special characters")

--- a/weighted_levenshtein/clev.pxd
+++ b/weighted_levenshtein/clev.pxd
@@ -3,7 +3,7 @@ from libc.float cimport DBL_MAX as DTYPE_MAX
 ctypedef double DTYPE_t
 
 cdef enum:
-    ALPHABET_SIZE = 128
+    ALPHABET_SIZE = 512
 
 
 cdef DTYPE_t c_damerau_levenshtein(
@@ -18,9 +18,9 @@ cdef DTYPE_t c_damerau_levenshtein(
 
 
 cdef DTYPE_t c_optimal_string_alignment(
-	unsigned char* word_m,
+	int[:] word_m,
 	Py_ssize_t m,
-	unsigned char* word_n,
+	int[:] word_n,
 	Py_ssize_t n,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
@@ -29,9 +29,9 @@ cdef DTYPE_t c_optimal_string_alignment(
 
 
 cdef DTYPE_t c_levenshtein(
-	unsigned char* word_m,
+	int[:] word_m,
 	Py_ssize_t m,
-	unsigned char* word_n,
+	int[:] word_n,
 	Py_ssize_t n,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,

--- a/weighted_levenshtein/clev.pxd
+++ b/weighted_levenshtein/clev.pxd
@@ -7,9 +7,9 @@ cdef enum:
 
 
 cdef DTYPE_t c_damerau_levenshtein(
-	unsigned char* str_a,
+	int[:] str_a,
 	Py_ssize_t len_a,
-	unsigned char* str_b,
+	int[:] str_b,
 	Py_ssize_t len_b,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,

--- a/weighted_levenshtein/clev.pxd
+++ b/weighted_levenshtein/clev.pxd
@@ -6,7 +6,7 @@ cdef enum:
     ALPHABET_SIZE = 512
 
 
-cdef DTYPE_t c_damerau_levenshtein(
+cdef DTYPE_t c_damerau_levenshtein_unicode(
 	int[:] str_a,
 	int[:] str_b,
 	DTYPE_t[::1] insert_costs,
@@ -15,7 +15,7 @@ cdef DTYPE_t c_damerau_levenshtein(
 	DTYPE_t[:,::1] transpose_costs) nogil
 
 
-cdef DTYPE_t c_optimal_string_alignment(
+cdef DTYPE_t c_optimal_string_alignment_unicode(
 	int[:] word_m,
 	int[:] word_n,
 	DTYPE_t[::1] insert_costs,
@@ -24,10 +24,41 @@ cdef DTYPE_t c_optimal_string_alignment(
 	DTYPE_t[:,::1] transpose_costs) nogil
 
 
-cdef DTYPE_t c_levenshtein(
+cdef DTYPE_t c_levenshtein_unicode(
 	int[:] word_m,
 	int[:] word_n,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
 	DTYPE_t[:,::1] substitute_costs) nogil
 
+
+cdef DTYPE_t c_damerau_levenshtein(
+	unsigned char* str_a,
+	Py_ssize_t len_a,
+	unsigned char* str_b,
+	Py_ssize_t len_b,
+	DTYPE_t[::1] insert_costs,
+	DTYPE_t[::1] delete_costs,
+	DTYPE_t[:,::1] substitute_costs,
+	DTYPE_t[:,::1] transpose_costs) nogil
+
+
+cdef DTYPE_t c_optimal_string_alignment(
+	unsigned char* word_m,
+	Py_ssize_t m,
+	unsigned char* word_n,
+	Py_ssize_t n,
+	DTYPE_t[::1] insert_costs,
+	DTYPE_t[::1] delete_costs,
+	DTYPE_t[:,::1] substitute_costs,
+	DTYPE_t[:,::1] transpose_costs) nogil
+
+
+cdef DTYPE_t c_levenshtein(
+	unsigned char* word_m,
+	Py_ssize_t m,
+	unsigned char* word_n,
+	Py_ssize_t n,
+	DTYPE_t[::1] insert_costs,
+	DTYPE_t[::1] delete_costs,
+	DTYPE_t[:,::1] substitute_costs) nogil

--- a/weighted_levenshtein/clev.pxd
+++ b/weighted_levenshtein/clev.pxd
@@ -8,9 +8,7 @@ cdef enum:
 
 cdef DTYPE_t c_damerau_levenshtein(
 	int[:] str_a,
-	Py_ssize_t len_a,
 	int[:] str_b,
-	Py_ssize_t len_b,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
 	DTYPE_t[:,::1] substitute_costs,
@@ -19,9 +17,7 @@ cdef DTYPE_t c_damerau_levenshtein(
 
 cdef DTYPE_t c_optimal_string_alignment(
 	int[:] word_m,
-	Py_ssize_t m,
 	int[:] word_n,
-	Py_ssize_t n,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
 	DTYPE_t[:,::1] substitute_costs,
@@ -30,9 +26,7 @@ cdef DTYPE_t c_optimal_string_alignment(
 
 cdef DTYPE_t c_levenshtein(
 	int[:] word_m,
-	Py_ssize_t m,
 	int[:] word_n,
-	Py_ssize_t n,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
 	DTYPE_t[:,::1] substitute_costs) nogil

--- a/weighted_levenshtein/clev.pxd
+++ b/weighted_levenshtein/clev.pxd
@@ -7,8 +7,10 @@ cdef enum:
 
 
 cdef DTYPE_t c_damerau_levenshtein_unicode(
-	int[:] str_a,
-	int[:] str_b,
+	unsigned int* word_m,
+	Py_ssize_t len1,
+	unsigned int* word_n,
+	Py_ssize_t len2,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
 	DTYPE_t[:,::1] substitute_costs,
@@ -16,8 +18,10 @@ cdef DTYPE_t c_damerau_levenshtein_unicode(
 
 
 cdef DTYPE_t c_optimal_string_alignment_unicode(
-	int[:] word_m,
-	int[:] word_n,
+	unsigned int* word_m,
+	Py_ssize_t len1,
+	unsigned int* word_n,
+	Py_ssize_t len2,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
 	DTYPE_t[:,::1] substitute_costs,
@@ -25,8 +29,10 @@ cdef DTYPE_t c_optimal_string_alignment_unicode(
 
 
 cdef DTYPE_t c_levenshtein_unicode(
-	int[:] word_m,
-	int[:] word_n,
+	unsigned int* word_m,
+	Py_ssize_t len1,
+	unsigned int* word_n,
+	Py_ssize_t len2,
 	DTYPE_t[::1] insert_costs,
 	DTYPE_t[::1] delete_costs,
 	DTYPE_t[:,::1] substitute_costs) nogil

--- a/weighted_levenshtein/clev.pyx
+++ b/weighted_levenshtein/clev.pyx
@@ -200,8 +200,7 @@ def damerau_levenshtein(
     intarr2 = convert_string_to_int_array(str2)
 
     return c_damerau_levenshtein(
-        intarr1, intarr1.size,
-        intarr2, intarr2.size,
+        intarr1, intarr2,
         insert_costs,
         delete_costs,
         substitute_costs,
@@ -212,8 +211,7 @@ dam_lev = damerau_levenshtein
 
 
 cdef DTYPE_t c_damerau_levenshtein(
-    int[:] str1, Py_ssize_t len1,
-    int[:] str2, Py_ssize_t len2,
+    int[:] str1, int[:] str2,
     DTYPE_t[::1] insert_costs,
     DTYPE_t[::1] delete_costs,
     DTYPE_t[:,::1] substitute_costs,
@@ -228,8 +226,11 @@ cdef DTYPE_t c_damerau_levenshtein(
         unsigned int char_i, char_j
         DTYPE_t cost, ret_val
         Py_ssize_t db, k, l
-
         Array2D d
+        Py_ssize_t len1, len2
+
+    len1 = str1.shape[0]
+    len2 = str2.shape[0]
 
     Array2D_init(&d, len1 + 2, len2 + 2)
 
@@ -327,8 +328,7 @@ def optimal_string_alignment(
     intarr2 = convert_string_to_int_array(str2)
 
     return c_optimal_string_alignment(
-        intarr1, intarr1.size,
-        intarr2, intarr2.size,
+        intarr1, intarr2,
         insert_costs,
         delete_costs,
         substitute_costs,
@@ -339,8 +339,7 @@ osa = optimal_string_alignment
 
 
 cdef DTYPE_t c_optimal_string_alignment(
-    int[:] str1, Py_ssize_t len1,
-    int[:] str2, Py_ssize_t len2,
+    int[:] str1, int[:] str2,
     DTYPE_t[::1] insert_costs,
     DTYPE_t[::1] delete_costs,
     DTYPE_t[:,::1] substitute_costs,
@@ -353,6 +352,10 @@ cdef DTYPE_t c_optimal_string_alignment(
         unsigned int char_i, char_j, prev_char_i, prev_char_j
         DTYPE_t ret_val
         Array2D d
+        Py_ssize_t len1, len2
+
+    len1 = str1.shape[0]
+    len2 = str2.shape[0]
 
     Array2D_init(&d, len1 + 1, len2 + 1)
 
@@ -428,8 +431,7 @@ def levenshtein(
     intarr2 = convert_string_to_int_array(str2)
 
     return c_levenshtein(
-        intarr1, intarr1.size,
-        intarr2, intarr2.size,
+        intarr1, intarr2,
         insert_costs,
         delete_costs,
         substitute_costs
@@ -439,8 +441,7 @@ lev = levenshtein
 
 
 cdef DTYPE_t c_levenshtein(
-    int[:] str1, Py_ssize_t len1,
-    int[:] str2, Py_ssize_t len2,
+    int[:] str1, int[:] str2,
     DTYPE_t[::1] insert_costs,
     DTYPE_t[::1] delete_costs,
     DTYPE_t[:,::1] substitute_costs) nogil:
@@ -452,6 +453,10 @@ cdef DTYPE_t c_levenshtein(
         unsigned int char_i, char_j
         DTYPE_t ret_val
         Array2D d
+        Py_ssize_t len1, len2
+
+    len1 = str1.shape[0]
+    len2 = str2.shape[0]
 
     Array2D_init(&d, len1 + 1, len2 + 1)
 


### PR DESCRIPTION
- The Damerau-Levenshtein method doesn't crash on windows anymore: fixes #16
- Unicode characters don't cause crash anymore: fixes #13 
- Added test cases to test unicode support
### Note:
The ALPHABET_SIZE constant has been increased to 512 because of the added Unicode support.
This should be enough for most users. A better alternative could be making ALPHABET_SIZE choosable by the user.