### PR TITLE
Fix sdist install for python >=3.9

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
 include weighted_levenshtein/clev.pxd
 include weighted_levenshtein/clev.pyx
-include weighted_levenshtein/clev.c
 recursive-exclude test *
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["Cython", "setuptools>=18.0", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,5 @@ setup(
     package_data={
         'weighted_levenshtein': ['clev.pxd', 'clev.pyx'],
     },
-    setup_requires=[
-        # Setuptools 18.0 properly handles Cython extensions.
-        'setuptools >= 18.0',
-        'cython',
-    ],
     ext_modules=[Extension("weighted_levenshtein.clev", ['weighted_levenshtein/clev.pyx'])],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as readme:
 
 setup(
     name='weighted_levenshtein',
-    version='0.2.1',
+    version='0.2.2',
     description=(
         'Library providing functions to calculate Levenshtein distance, Optimal String Alignment distance, '
         'and Damerau-Levenshtein distance, where the cost of each operation can be weighted by letter.'


### PR DESCRIPTION
This removes the `clev.c` file from the sdists, which was generated against an older cython version and references APIs removed in python 3.9. By removing the `.c` file from the dist, a fresh one will be generated for each install for the correct python version (and likely newer cython versions).

I also switched the build requirements over to [PEP 517](https://peps.python.org/pep-0517/), which silences this warning during `python3 setup.py sdist`:
```
SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
```

Closes #25
